### PR TITLE
Update "Hello World" example to specify language

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ const client = new Riza({
 });
 
 async function main() {
-  const response = await client.command.exec({ code: 'print("Hello world!")' });
+  const response = await client.command.exec({
+    language: "PYTHON",
+    code: "print('Hello, world!')",
+  });
 
-  console.log(response.exit_code);
+  console.log(response.stdout);
 }
 
 main();


### PR DESCRIPTION
The existing Hello World example fails with a `BadRequestError: 400 unknown language: UNSPECIFIED`.

This version of the Node.js package uses [the code sample from the docs](https://docs.riza.io/guides/how-it-works), including `language: "PYTHON"` and using the `response.stdout` value.

There are a number of example of only `code: 'print("Hello world!")'` without `language: "PYTHON"`; I can add them all, if it's required parameter for each instance.